### PR TITLE
Fix e2e_asr_maskctc.py to make RTF computable

### DIFF
--- a/espnet/nets/pytorch_backend/e2e_asr_maskctc.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_maskctc.py
@@ -216,6 +216,9 @@ class E2E(E2ETransformer):
 
         self.eval()
         h = self.encode(x).unsqueeze(0)
+        
+        input_len = h.squeeze(0)
+        logging.info("input lengths: " + str(input_len.size(0)))
 
         # greedy ctc outputs
         ctc_probs, ctc_ids = torch.exp(self.ctc.log_softmax(h)).max(dim=-1)


### PR DESCRIPTION
Output enough log information required by calculate_rtf.py